### PR TITLE
Cleanup & Refactor clientizen support

### DIFF
--- a/src/main/java/com/denizenscript/depenizen/bukkit/Depenizen.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/Depenizen.java
@@ -41,7 +41,7 @@ public class Depenizen extends JavaPlugin {
             Debug.echoError("Cannot load Depenizen-Bungee bridge: Internal exception was thrown!");
             Debug.echoError(ex);
         }
-        ClientizenSupport.instance = new ClientizenSupport();
+        ClientizenSupport.init();
         DebugSubmitter.debugHeaderLines.add(() -> "Depenizen Bridges loaded (" + loadedBridges.size() + "): " + ChatColor.DARK_GREEN + String.join(", ", loadedBridges.keySet()));
         Debug.log("Depenizen loaded! <A>" + loadedBridges.size() + "<W> plugin bridge(s) loaded (of <A>" + allBridges.size() + "<W> available)");
     }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/Channels.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/Channels.java
@@ -2,6 +2,6 @@ package com.denizenscript.depenizen.bukkit.clientizen;
 
 public class Channels {
     public static final String CHANNEL_NAMESPACE = "clientizen";
-    public static final String SET_SCRIPTS = CHANNEL_NAMESPACE + "set_scripts";
-    public static final String RECIVE_CONFIRM = CHANNEL_NAMESPACE + "receive_confirmation";
+    public static final String SET_SCRIPTS = CHANNEL_NAMESPACE + ":" + "set_scripts";
+    public static final String RECEIVE_CONFIRM = CHANNEL_NAMESPACE + ":" + "receive_confirmation";
 }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/Channels.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/Channels.java
@@ -1,0 +1,7 @@
+package com.denizenscript.depenizen.bukkit.clientizen;
+
+public class Channels {
+    public static final String CHANNEL_NAMESPACE = "clientizen";
+    public static final String SET_SCRIPTS = CHANNEL_NAMESPACE + "set_scripts";
+    public static final String RECIVE_CONFIRM = CHANNEL_NAMESPACE + "receive_confirmation";
+}

--- a/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/ClientizenSupport.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/ClientizenSupport.java
@@ -57,8 +57,8 @@ public class ClientizenSupport implements Listener {
                 continue;
             }
             try (FileInputStream stream = new FileInputStream(file)) {
-                String contents = ScriptHelper.convertStreamToString(stream);
-                clientizenScripts.put(name, contents);
+                // TODO: clear comments server-side
+                clientizenScripts.put(name, ScriptHelper.convertStreamToString(stream));
                 Debug.log("Loaded client script: " + name);
             }
             catch (Exception e) {

--- a/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/ClientizenSupport.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/ClientizenSupport.java
@@ -38,7 +38,7 @@ public class ClientizenSupport implements Listener {
             return new ElementTag(clientizenPlayers.contains(object.getUUID()));
         });
         NetworkManager.init();
-        NetworkManager.registerInChannel(Channels.RECIVE_CONFIRM, (player, message) -> {
+        NetworkManager.registerInChannel(Channels.RECEIVE_CONFIRM, (player, message) -> {
             Debug.log("Received confirmation from " + player.getName());
             clientizenPlayers.add(player.getUniqueId());
             // Wait a little to make sure the client is ready to receive packets

--- a/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/ClientizenSupport.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/ClientizenSupport.java
@@ -30,7 +30,7 @@ public class ClientizenSupport implements Listener {
 
     public static void init() {
         instance = new ClientizenSupport();
-        clientizenFolder = new File(Denizen.getInstance().getDataFolder(), "client-scripts");
+        clientizenFolder = new File(Denizen.instance.getDataFolder(), "client-scripts");
         clientizenFolder.mkdir();
         Bukkit.getPluginManager().registerEvents(instance, Depenizen.instance);
         // A tag for testing

--- a/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/ClientizenSupport.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/ClientizenSupport.java
@@ -13,49 +13,41 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerQuitEvent;
-import org.bukkit.plugin.messaging.PluginMessageListener;
-import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.*;
 
-public class ClientizenSupport implements Listener, PluginMessageListener {
+public class ClientizenSupport implements Listener {
 
     public static ClientizenSupport instance;
 
     public static final Map<String, String> clientizenScripts = new HashMap<>();
+    public static DataSerializer scriptsSerializer;
     public static final Set<UUID> clientizenPlayers = new HashSet<>();
 
-    public static final File clientizenFolder;
-    public static final String CHANNEL_NAMESPACE = "clientizen";
+    public static File clientizenFolder;
 
-    static {
+    public static void init() {
+        instance = new ClientizenSupport();
         clientizenFolder = new File(Denizen.getInstance().getDataFolder(), "client-scripts");
-        clientizenFolder.mkdirs();
-    }
-
-    public ClientizenSupport() {
-        Bukkit.getPluginManager().registerEvents(this, Depenizen.instance);
+        clientizenFolder.mkdir();
+        Bukkit.getPluginManager().registerEvents(instance, Depenizen.instance);
+        // A tag for testing
         PlayerTag.registerOnlineOnlyTag(ElementTag.class, "is_clientizen", (attribute, object) -> {
             return new ElementTag(clientizenPlayers.contains(object.getUUID()));
         });
-        registerInChannel(Channel.RECIVE_CONFIRM);
-        registerOutChannel(Channel.SET_SCRIPTS);
-        Debug.log("ClientizenSupport", "Clientizen support enabled!");
+        NetworkManager.init();
+        NetworkManager.registerInChannel(Channels.RECIVE_CONFIRM, (player, message) -> {
+            Debug.log("Received confirmation from " + player.getName());
+            clientizenPlayers.add(player.getUniqueId());
+            // Wait a little to make sure the client is ready to receive packets
+            Bukkit.getScheduler().runTaskLater(Depenizen.instance, () -> resendClientScriptsTo(player), 20);
+        });
+        Debug.log("Clientizen support enabled!");
     }
 
-    public void registerInChannel(Channel channel) {
-        Bukkit.getMessenger().registerIncomingPluginChannel(Depenizen.instance, channel.getChannel(), this);
-        Debug.log("ClientizenSupport", "Registered in channel " + channel);
-    }
-
-    public void registerOutChannel(Channel channel) {
-        Bukkit.getMessenger().registerOutgoingPluginChannel(Depenizen.instance, channel.getChannel());
-        Debug.log("ClientizenSupport", "Registered out channel " + channel);
-    }
-
-    public static void refershClientScripts() {
+    public static void reloadClientScripts() {
         clientizenScripts.clear();
         List<File> scriptFiles = CoreUtilities.listDScriptFiles(clientizenFolder);
         for (File file : scriptFiles) {
@@ -64,10 +56,8 @@ public class ClientizenSupport implements Listener, PluginMessageListener {
                 Debug.echoError("Multiple script files named '" + name + "' found in client-scripts folder!");
                 continue;
             }
-            try {
-                FileInputStream stream = new FileInputStream(file);
+            try (FileInputStream stream = new FileInputStream(file)) {
                 String contents = ScriptHelper.convertStreamToString(stream);
-                stream.close();
                 clientizenScripts.put(name, contents);
                 Debug.log("Loaded client script: " + name);
             }
@@ -76,17 +66,12 @@ public class ClientizenSupport implements Listener, PluginMessageListener {
                 Debug.echoError(e);
             }
         }
+        scriptsSerializer = new DataSerializer().writeStringMap(clientizenScripts);
     }
 
     public static void resendClientScripts() {
-        DataSerializer serializer = new DataSerializer();
-        serializer.writeStringMap(clientizenScripts);
         for (UUID uuid : clientizenPlayers) {
-            Player player = Bukkit.getPlayer(uuid);
-            if (player == null) {
-                continue;
-            }
-            send(player, Channel.SET_SCRIPTS, serializer);
+            resendClientScriptsTo(Bukkit.getPlayer(uuid));
         }
     }
 
@@ -94,14 +79,7 @@ public class ClientizenSupport implements Listener, PluginMessageListener {
         if (player == null) {
             return;
         }
-        DataSerializer serializer = new DataSerializer();
-        serializer.writeStringMap(clientizenScripts);
-        send(player, Channel.SET_SCRIPTS, serializer);
-    }
-
-    public static void send(Player player, Channel channel, DataSerializer serializer) {
-        player.sendPluginMessage(Depenizen.instance, channel.getChannel(), serializer == null ? new byte[0] : serializer.toByteArray());
-        Debug.log("ClientizenSupport", "Sent plugin message to " + player.getName() + " on channel " + channel);
+        NetworkManager.send(Channels.SET_SCRIPTS, player, scriptsSerializer);
     }
 
     @EventHandler
@@ -111,57 +89,7 @@ public class ClientizenSupport implements Listener, PluginMessageListener {
 
     @EventHandler
     public void onScriptsReload(ScriptReloadEvent event) {
-        refershClientScripts();
+        reloadClientScripts();
         resendClientScripts();
-    }
-
-    @Override
-    public void onPluginMessageReceived(@NotNull String channelString, @NotNull Player player, @NotNull byte[] bytes) {
-        Channel channel = Channel.fromPath(channelString.substring(CHANNEL_NAMESPACE.length() + 1));
-        switch (channel) {
-            case RECIVE_CONFIRM:
-                Debug.log("ClientizenSupport", "Received confirmation from " + player.getName());
-                clientizenPlayers.add(player.getUniqueId());
-                // Wait a little to make sure the client is ready to receive packets
-                Bukkit.getScheduler().runTaskLater(Depenizen.instance, () -> {
-                    resendClientScriptsTo(player);
-                }, 20);
-        }
-    }
-
-    enum Channel {
-        SET_SCRIPTS("set_scripts"),
-        RECIVE_CONFIRM("receive_confirmation");
-
-        private final String path;
-        private final String channel;
-
-        Channel(String channel) {
-            this.path = channel;
-            this.channel = CHANNEL_NAMESPACE + ":" + channel;
-        }
-
-        public String getChannel() {
-            return channel;
-        }
-
-        public String getPath() {
-            return path;
-        }
-
-        // TODO: A more efficient way of doing this?
-        public static Channel fromPath(String path) {
-            for (Channel channel : values()) {
-                if (channel.path.equals(path)) {
-                    return channel;
-                }
-            }
-            return null;
-        }
-
-        @Override
-        public String toString() {
-            return channel;
-        }
     }
 }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/DataDeserializer.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/DataDeserializer.java
@@ -1,0 +1,75 @@
+package com.denizenscript.depenizen.bukkit.clientizen;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DataDeserializer {
+
+    private final DataInput input;
+
+    public DataDeserializer(byte[] bytes) {
+        input = new DataInputStream(new ByteArrayInputStream(bytes));
+    }
+
+    public int readInt() {
+        try {
+            return input.readInt();
+        }
+        catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public byte[] readByteArray() {
+        byte[] bytes = new byte[readInt()];
+        try {
+            input.readFully(bytes);
+        }
+        catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+        return bytes;
+    }
+
+    public String readString() {
+        return new String(readByteArray(), StandardCharsets.UTF_8);
+    }
+
+    public List<String> readStringList() {
+        List<String> stringList = new ArrayList<>();
+        int size = readInt();
+        for (int i = 0; i < size; i++) {
+            stringList.add(readString());
+        }
+        return stringList;
+    }
+
+    public Map<String, String> readStringMap() {
+        Map<String, String> stringMap = new HashMap<>();
+        int size = readInt();
+        for (int i = 0; i < size; i++) {
+            String key = readString();
+            String value = readString();
+            stringMap.put(key, value);
+        }
+        return stringMap;
+    }
+
+    public Map<String, List<String>> readStringListMap() {
+        Map<String, List<String>> stringListMap = new HashMap<>();
+        int size = readInt();
+        for (int i = 0; i < size; i++) {
+            String key = readString();
+            List<String> value = readStringList();
+            stringListMap.put(key, value);
+        }
+        return stringListMap;
+    }
+}

--- a/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/DataSerializer.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/DataSerializer.java
@@ -13,8 +13,8 @@ import java.util.Map;
 
 public class DataSerializer {
 
-    public DataOutput output;
-    public ByteArrayOutputStream outputStream;
+    private final DataOutput output;
+    private final ByteArrayOutputStream outputStream;
 
     public DataSerializer() {
         outputStream = new ByteArrayOutputStream();

--- a/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/DataSerializer.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/DataSerializer.java
@@ -21,50 +21,54 @@ public class DataSerializer {
         output = new DataOutputStream(outputStream);
     }
 
-    public void writeInt(int i) {
+    public DataSerializer writeInt(int i) {
         try {
             output.writeInt(i);
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             Debug.echoError(new IllegalStateException(e));
         }
+        return this;
     }
 
-    public void writeByteArray(@NotNull byte[] bytes) {
+    public DataSerializer writeByteArray(@NotNull byte[] bytes) {
         try {
             writeInt(bytes.length);
             output.write(bytes);
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             Debug.echoError(new IllegalStateException(e));
         }
+        return this;
     }
 
-    public void writeString(@NotNull String s) {
+    public DataSerializer writeString(@NotNull String s) {
         writeByteArray(s.getBytes(StandardCharsets.UTF_8));
+        return this;
     }
 
-    public void writeStringList(@NotNull Collection<String> strings) {
+    public DataSerializer writeStringList(@NotNull Collection<String> strings) {
         writeInt(strings.size());
         for (String s : strings) {
             writeString(s);
         }
+        return this;
     }
 
-    public void writeStringListMap(@NotNull Map<String, Collection<String>> map) {
+    public DataSerializer writeStringListMap(@NotNull Map<String, Collection<String>> map) {
         writeInt(map.size());
         for (Map.Entry<String, Collection<String>> entry : map.entrySet()) {
             writeString(entry.getKey());
             writeStringList(entry.getValue());
         }
+        return this;
     }
 
-    public void writeStringMap(Map<String, String> stringMap) {
-            writeInt(stringMap.size());
-            for (Map.Entry<String, String> entry : stringMap.entrySet()) {
-                writeString(entry.getKey());
-                writeString(entry.getValue());
-            }
+    public DataSerializer writeStringMap(Map<String, String> stringMap) {
+        writeInt(stringMap.size());
+        for (Map.Entry<String, String> entry : stringMap.entrySet()) {
+            writeString(entry.getKey());
+            writeString(entry.getValue());
+        }
+        return this;
     }
 
     public byte[] toByteArray() {

--- a/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/DataSerializer.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/DataSerializer.java
@@ -24,7 +24,8 @@ public class DataSerializer {
     public DataSerializer writeInt(int i) {
         try {
             output.writeInt(i);
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             Debug.echoError(new IllegalStateException(e));
         }
         return this;
@@ -34,7 +35,8 @@ public class DataSerializer {
         try {
             writeInt(bytes.length);
             output.write(bytes);
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             Debug.echoError(new IllegalStateException(e));
         }
         return this;

--- a/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/NetworkManager.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/NetworkManager.java
@@ -21,8 +21,8 @@ public class NetworkManager implements PluginMessageListener {
         instance = new NetworkManager();
     }
 
-    public static void registerInChannel(String channel, ClientizenReceiver runnable) {
-        if (channel == null || runnable == null) {
+    public static void registerInChannel(String channel, ClientizenReceiver receiver) {
+        if (channel == null || receiver == null) {
             return;
         }
         if (inChannelRunnables.containsKey(channel)) {
@@ -30,7 +30,7 @@ public class NetworkManager implements PluginMessageListener {
             return;
         }
         Bukkit.getMessenger().registerIncomingPluginChannel(Depenizen.instance, channel, instance);
-        inChannelRunnables.put(channel, runnable);
+        inChannelRunnables.put(channel, receiver);
     }
 
     public static void send(String channel, Player target, DataSerializer message) {

--- a/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/NetworkManager.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/NetworkManager.java
@@ -1,0 +1,48 @@
+package com.denizenscript.depenizen.bukkit.clientizen;
+
+import com.denizenscript.depenizen.bukkit.Depenizen;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.messaging.PluginMessageListener;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class NetworkManager implements PluginMessageListener {
+
+    private static NetworkManager instance;
+    private static final Map<String, InChannelRunnable> inChannelRunnables = new HashMap<>();
+
+    public static void init() {
+        instance = new NetworkManager();
+    }
+
+    public static void registerInChannel(String channel, InChannelRunnable runnable) {
+        if (channel == null || runnable == null) {
+            return;
+        }
+        Bukkit.getMessenger().registerIncomingPluginChannel(Depenizen.instance, channel, instance);
+        inChannelRunnables.put(channel, runnable);
+    }
+
+    public static void send(String channel, Player target, DataSerializer message) {
+        if (channel == null || target == null || message == null) {
+            return;
+        }
+        if (!Bukkit.getMessenger().isOutgoingChannelRegistered(Depenizen.instance, channel)) {
+            Bukkit.getMessenger().registerOutgoingPluginChannel(Depenizen.instance, channel);
+        }
+        target.sendPluginMessage(Depenizen.instance, channel, message.toByteArray());
+    }
+
+    @Override
+    public void onPluginMessageReceived(@NotNull String channel, @NotNull Player player, @NotNull byte[] message) {
+        inChannelRunnables.get(channel).run(player, message);
+    }
+
+    @FunctionalInterface
+    public interface InChannelRunnable {
+        public void run(Player player, byte[] message);
+    }
+}

--- a/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/NetworkManager.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/NetworkManager.java
@@ -1,5 +1,6 @@
 package com.denizenscript.depenizen.bukkit.clientizen;
 
+import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.depenizen.bukkit.Depenizen;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -14,6 +15,8 @@ public class NetworkManager implements PluginMessageListener {
     private static NetworkManager instance;
     private static final Map<String, InChannelRunnable> inChannelRunnables = new HashMap<>();
 
+    private static final byte[] EMPTY = new byte[0];
+
     public static void init() {
         instance = new NetworkManager();
     }
@@ -22,18 +25,26 @@ public class NetworkManager implements PluginMessageListener {
         if (channel == null || runnable == null) {
             return;
         }
+        if (inChannelRunnables.containsKey(channel)) {
+            Debug.echoError("Tried registering plugin channel '" + channel + "', but it is already registered!");
+            return;
+        }
         Bukkit.getMessenger().registerIncomingPluginChannel(Depenizen.instance, channel, instance);
         inChannelRunnables.put(channel, runnable);
     }
 
     public static void send(String channel, Player target, DataSerializer message) {
-        if (channel == null || target == null || message == null) {
+        send(channel, target, message != null ? message.toByteArray() : null);
+    }
+
+    public static void send(String channel, Player target, byte[] message) {
+        if (channel == null || target == null) {
             return;
         }
         if (!Bukkit.getMessenger().isOutgoingChannelRegistered(Depenizen.instance, channel)) {
             Bukkit.getMessenger().registerOutgoingPluginChannel(Depenizen.instance, channel);
         }
-        target.sendPluginMessage(Depenizen.instance, channel, message.toByteArray());
+        target.sendPluginMessage(Depenizen.instance, channel, message != null ? message : EMPTY);
     }
 
     @Override
@@ -43,6 +54,6 @@ public class NetworkManager implements PluginMessageListener {
 
     @FunctionalInterface
     public interface InChannelRunnable {
-        public void run(Player player, byte[] message);
+        void run(Player player, byte[] message);
     }
 }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/NetworkManager.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/NetworkManager.java
@@ -13,7 +13,7 @@ import java.util.Map;
 public class NetworkManager implements PluginMessageListener {
 
     private static NetworkManager instance;
-    private static final Map<String, ClientizenReceiver> inChannelRunnables = new HashMap<>();
+    private static final Map<String, ClientizenReceiver> registeredReceivers = new HashMap<>();
 
     private static final byte[] EMPTY = new byte[0];
 
@@ -25,12 +25,12 @@ public class NetworkManager implements PluginMessageListener {
         if (channel == null || receiver == null) {
             return;
         }
-        if (inChannelRunnables.containsKey(channel)) {
+        if (registeredReceivers.containsKey(channel)) {
             Debug.echoError("Tried registering plugin channel '" + channel + "', but it is already registered!");
             return;
         }
         Bukkit.getMessenger().registerIncomingPluginChannel(Depenizen.instance, channel, instance);
-        inChannelRunnables.put(channel, receiver);
+        registeredReceivers.put(channel, receiver);
     }
 
     public static void send(String channel, Player target, DataSerializer message) {
@@ -49,7 +49,7 @@ public class NetworkManager implements PluginMessageListener {
 
     @Override
     public void onPluginMessageReceived(@NotNull String channel, @NotNull Player player, @NotNull byte[] message) {
-        inChannelRunnables.get(channel).receive(player, message);
+        registeredReceivers.get(channel).receive(player, message);
     }
 
     @FunctionalInterface

--- a/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/NetworkManager.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/NetworkManager.java
@@ -49,11 +49,11 @@ public class NetworkManager implements PluginMessageListener {
 
     @Override
     public void onPluginMessageReceived(@NotNull String channel, @NotNull Player player, @NotNull byte[] message) {
-        registeredReceivers.get(channel).receive(player, message);
+        registeredReceivers.get(channel).receive(player, new DataDeserializer(message));
     }
 
     @FunctionalInterface
     public interface ClientizenReceiver {
-        void receive(Player player, byte[] message);
+        void receive(Player player, DataDeserializer message);
     }
 }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/NetworkManager.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/NetworkManager.java
@@ -13,7 +13,7 @@ import java.util.Map;
 public class NetworkManager implements PluginMessageListener {
 
     private static NetworkManager instance;
-    private static final Map<String, InChannelRunnable> inChannelRunnables = new HashMap<>();
+    private static final Map<String, ClientizenReceiver> inChannelRunnables = new HashMap<>();
 
     private static final byte[] EMPTY = new byte[0];
 
@@ -21,7 +21,7 @@ public class NetworkManager implements PluginMessageListener {
         instance = new NetworkManager();
     }
 
-    public static void registerInChannel(String channel, InChannelRunnable runnable) {
+    public static void registerInChannel(String channel, ClientizenReceiver runnable) {
         if (channel == null || runnable == null) {
             return;
         }
@@ -49,11 +49,11 @@ public class NetworkManager implements PluginMessageListener {
 
     @Override
     public void onPluginMessageReceived(@NotNull String channel, @NotNull Player player, @NotNull byte[] message) {
-        inChannelRunnables.get(channel).run(player, message);
+        inChannelRunnables.get(channel).receive(player, message);
     }
 
     @FunctionalInterface
-    public interface InChannelRunnable {
-        void run(Player player, byte[] message);
+    public interface ClientizenReceiver {
+        void receive(Player player, byte[] message);
     }
 }


### PR DESCRIPTION
Adds `NetworkManager` - lets you cleanly listen to plugin messages and send plugin messages to players.
Replaces `Channel` Enum with `Channels` class holding all channel names.
Allows chaining `DataSerializer` calls (I.e. it returns itself on all of it's `write*` methods now).
Caches a `DataSerializer` for scripts (to avoid writing the scripts into a new one whenever a player joins).
