### PR TITLE
Add `clientrun` command

### DIFF
--- a/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/ClientizenSupport.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/ClientizenSupport.java
@@ -3,12 +3,14 @@ package com.denizenscript.depenizen.bukkit.clientizen;
 import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.events.bukkit.ScriptReloadEvent;
 import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizencore.DenizenCore;
 import com.denizenscript.denizencore.events.ScriptEvent;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.scripts.ScriptHelper;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.depenizen.bukkit.Depenizen;
+import com.denizenscript.depenizen.bukkit.clientizen.commands.ClientRunCommand;
 import com.denizenscript.depenizen.bukkit.clientizen.network.Channels;
 import com.denizenscript.depenizen.bukkit.clientizen.network.DataSerializer;
 import com.denizenscript.depenizen.bukkit.clientizen.network.NetworkManager;
@@ -48,6 +50,8 @@ public class ClientizenSupport implements Listener {
         // Register ClientizenEvent
         ScriptEvent.registerScriptEvent(ClientizenEventScriptEvent.class);
         NetworkManager.registerInChannel(Channels.RECEIVE_EVENT, (player, message) -> ClientizenEventScriptEvent.instance.tryFire(player, message));
+        // Register ClientRunCommand
+        DenizenCore.commandRegistry.registerCommand(ClientRunCommand.class);
         Debug.log("Clientizen support enabled!");
     }
 

--- a/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/commands/ClientRunCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/commands/ClientRunCommand.java
@@ -23,7 +23,7 @@ public class ClientRunCommand extends AbstractCommand {
 
     public ClientRunCommand() {
         setName("clientrun");
-        setSyntax("clientrun [<script>] (path:<name>) (def.<name>:<value>/defmap:<map>)");
+        setSyntax("clientrun [<script>] (path:<name>) (def.<name>:<value>) (defmap:<map>)");
         setRequiredArguments(1, -1);
         allowedDynamicPrefixes = true;
     }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/commands/ClientRunCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/commands/ClientRunCommand.java
@@ -51,7 +51,7 @@ public class ClientRunCommand extends AbstractCommand {
             }
             else if (!scriptEntry.hasObject("path")
                     && arg.matchesPrefix("path")) {
-                scriptEntry.addObject("path", arg.asElement());
+                scriptEntry.addObject("path", arg.asElement().asString());
             }
             else if (!scriptEntry.hasObject("script")) {
                 scriptEntry.addObject("script", arg.asElement());
@@ -70,14 +70,14 @@ public class ClientRunCommand extends AbstractCommand {
 
     @Override
     public void execute(ScriptEntry scriptEntry) {
-        ElementTag path = scriptEntry.getElement("path");
+        String path = (String) scriptEntry.getObject("path");
         ElementTag script = scriptEntry.getElement("script");
         MapTag defMap = scriptEntry.getObjectTag("def_map");
         PlayerTag clientizenPlayer = scriptEntry.getObjectTag("player");
         if (scriptEntry.dbCallShouldDebug()) {
-            Debug.report(scriptEntry, getName(), script, clientizenPlayer, path, defMap);
+            Debug.report(scriptEntry, getName(), script, clientizenPlayer, db("path", path), defMap);
         }
-        Map<String, String> stringDefMap = null;
+        Map<String, String> stringDefMap = Map.of();
         if (defMap != null) {
             stringDefMap = new HashMap<>(defMap.map.size());
             for (Map.Entry<StringHolder, ObjectTag> entry : defMap.map.entrySet()) {
@@ -86,8 +86,8 @@ public class ClientRunCommand extends AbstractCommand {
         }
         DataSerializer runData = new DataSerializer()
                 .writeString(script.asString())
-                .writeString(path != null ? path.asString() : "")
-                .writeStringMap(stringDefMap != null ? stringDefMap : Map.of());
+                .writeNullable(path, DataSerializer::writeString)
+                .writeStringMap(stringDefMap);
         NetworkManager.send(Channels.RUN_CLIENT_SCRIPT, clientizenPlayer.getPlayerEntity(), runData);
     }
 }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/commands/ClientRunCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/commands/ClientRunCommand.java
@@ -1,0 +1,94 @@
+package com.denizenscript.depenizen.bukkit.clientizen.commands;
+
+import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizen.utilities.Utilities;
+import com.denizenscript.denizencore.exceptions.InvalidArgumentsException;
+import com.denizenscript.denizencore.objects.Argument;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.core.MapTag;
+import com.denizenscript.denizencore.scripts.ScriptEntry;
+import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
+import com.denizenscript.denizencore.utilities.text.StringHolder;
+import com.denizenscript.depenizen.bukkit.clientizen.ClientizenSupport;
+import com.denizenscript.depenizen.bukkit.clientizen.network.Channels;
+import com.denizenscript.depenizen.bukkit.clientizen.network.DataSerializer;
+import com.denizenscript.depenizen.bukkit.clientizen.network.NetworkManager;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ClientRunCommand extends AbstractCommand {
+
+    public ClientRunCommand() {
+        setName("clientrun");
+        setSyntax("clientrun [<script>] (path:<name>) (def.<name>:<value>/defmap:<map>)");
+        setRequiredArguments(1, -1);
+        allowedDynamicPrefixes = true;
+    }
+
+    @Override
+    public void parseArgs(ScriptEntry scriptEntry) throws InvalidArgumentsException {
+        PlayerTag player = Utilities.getEntryPlayer(scriptEntry);
+        if (player == null || !ClientizenSupport.clientizenPlayers.contains(player.getUUID())) {
+            throw new InvalidArgumentsException("No valid clientizen player found.");
+        }
+        scriptEntry.addObject("player", player);
+        MapTag defMap = new MapTag();
+        for (Argument arg : scriptEntry) {
+            if (arg.matchesPrefix("defmap")
+                    && arg.matchesArgumentType(MapTag.class)) {
+                defMap.map.putAll(arg.asType(MapTag.class).map);
+            }
+            else if (arg.hasPrefix()
+                    && arg.getPrefix().getRawValue().startsWith("def.")) {
+                defMap.putObject(arg.getPrefix().getRawValue().substring("def.".length()), arg.object);
+            }
+            else if (!scriptEntry.hasObject("script")
+                    && arg.limitToOnlyPrefix("script")) {
+                scriptEntry.addObject("script", arg.asElement());
+            }
+            else if (!arg.hasPrefix() && arg.getRawValue().startsWith("def.") && arg.getRawValue().contains(":")) {
+                int colon = arg.getRawValue().indexOf(':');
+                defMap.putObject(arg.getRawValue().substring("def.".length(), colon), new ElementTag(arg.getRawValue().substring(colon + 1)));
+            }
+            else if (!scriptEntry.hasObject("path")
+                    && arg.matchesPrefix("path")) {
+                scriptEntry.addObject("path", arg.asElement());
+            }
+            else {
+                arg.reportUnhandled();
+            }
+        }
+        if (!scriptEntry.hasObject("script")) {
+            throw new InvalidArgumentsException("Must specify a script to run on the client.");
+        }
+        if (!defMap.map.isEmpty()) {
+            scriptEntry.addObject("def_map", defMap);
+        }
+    }
+
+    @Override
+    public void execute(ScriptEntry scriptEntry) {
+        ElementTag path = scriptEntry.getElement("path");
+        ElementTag script = scriptEntry.getElement("script");
+        MapTag defMap = scriptEntry.getObjectTag("def_map");
+        PlayerTag clientizenPlayer = scriptEntry.getObjectTag("player");
+        if (scriptEntry.dbCallShouldDebug()) {
+            Debug.report(scriptEntry, getName(), script, clientizenPlayer, path, defMap);
+        }
+        Map<String, String> stringDefMap = null;
+        if (defMap != null) {
+            stringDefMap = new HashMap<>(defMap.map.size());
+            for (Map.Entry<StringHolder, ObjectTag> entry : defMap.map.entrySet()) {
+                stringDefMap.put(entry.getKey().str, entry.getValue().savable());
+            }
+        }
+        DataSerializer runData = new DataSerializer()
+                .writeString(script.asString())
+                .writeString(path != null ? path.asString() : "")
+                .writeStringMap(stringDefMap != null ? stringDefMap : Map.of());
+        NetworkManager.send(Channels.RUN_CLIENT_SCRIPT, clientizenPlayer.getPlayerEntity(), runData);
+    }
+}

--- a/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/commands/ClientRunCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/commands/ClientRunCommand.java
@@ -45,10 +45,6 @@ public class ClientRunCommand extends AbstractCommand {
                     && arg.getPrefix().getRawValue().startsWith("def.")) {
                 defMap.putObject(arg.getPrefix().getRawValue().substring("def.".length()), arg.object);
             }
-            else if (!scriptEntry.hasObject("script")
-                    && arg.limitToOnlyPrefix("script")) {
-                scriptEntry.addObject("script", arg.asElement());
-            }
             else if (!arg.hasPrefix() && arg.getRawValue().startsWith("def.") && arg.getRawValue().contains(":")) {
                 int colon = arg.getRawValue().indexOf(':');
                 defMap.putObject(arg.getRawValue().substring("def.".length(), colon), new ElementTag(arg.getRawValue().substring(colon + 1)));
@@ -56,6 +52,9 @@ public class ClientRunCommand extends AbstractCommand {
             else if (!scriptEntry.hasObject("path")
                     && arg.matchesPrefix("path")) {
                 scriptEntry.addObject("path", arg.asElement());
+            }
+            else if (!scriptEntry.hasObject("script")) {
+                scriptEntry.addObject("script", arg.asElement());
             }
             else {
                 arg.reportUnhandled();

--- a/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/network/Channels.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/network/Channels.java
@@ -5,6 +5,7 @@ public class Channels {
     public static final String SET_SCRIPTS = id("set_scripts");
     public static final String RECEIVE_CONFIRM = id("receive_confirmation");
     public static final String RECEIVE_EVENT = id("fire_event");
+    public static final String RUN_CLIENT_SCRIPT = id("run_script");
 
     public static String id(String key) {
         return CHANNEL_NAMESPACE + ':' + key;

--- a/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/network/DataSerializer.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/network/DataSerializer.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 public class DataSerializer {
 
@@ -89,6 +90,17 @@ public class DataSerializer {
         for (Map.Entry<String, String> entry : stringMap.entrySet()) {
             writeString(entry.getKey());
             writeString(entry.getValue());
+        }
+        return this;
+    }
+
+    public <T> DataSerializer writeNullable(T object, BiConsumer<DataSerializer, T> writeMethod) {
+        if (object != null) {
+            writeBoolean(true);
+            writeMethod.accept(this, object);
+        }
+        else {
+            writeBoolean(false);
         }
         return this;
     }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/network/DataSerializer.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/network/DataSerializer.java
@@ -21,6 +21,16 @@ public class DataSerializer {
         output = new DataOutputStream(outputStream);
     }
 
+    public DataSerializer writeBoolean(boolean bool) {
+        try {
+            output.writeBoolean(bool);
+        }
+        catch (IOException e) {
+            Debug.echoError(new IllegalStateException(e));
+        }
+        return this;
+    }
+
     public DataSerializer writeInt(int i) {
         try {
             output.writeInt(i);


### PR DESCRIPTION
## Additions

- `clientrun` command - runs a script on a Clientizen player's client.
- `run_script` channel - used by the `clientrun` command.
- `DataSerializer#writeBoolean`
- `DataSerializer#writeNullable` - writes nullable data (data prefixed with a boolean indicating whether it's present or not).